### PR TITLE
Refactoring

### DIFF
--- a/Controller/RepeatingController.php
+++ b/Controller/RepeatingController.php
@@ -20,6 +20,18 @@ class RepeatingController extends TemplateController
     const MODULE_IDENTIFIER = 'campaignchain-repeating';
     const TRIGGER_HOOK = 'campaignchain-date-repeat';
 
+    public function indexAction()
+    {
+        $repository_campaigns = $this->getDoctrine()->getRepository('CampaignChainCoreBundle:Campaign')->getCampaignsByModule(static::MODULE_IDENTIFIER);
+
+        return $this->render(
+            'CampaignChainCampaignRepeatingBundle::index.html.twig',
+            array(
+                'page_title' => static::CAMPAIGN_DISPLAY_NAME . 's',
+                'repository_campaigns' => $repository_campaigns,
+            ));
+    }
+
     public function copyAction(Request $request, $id)
     {
         $campaignService = $this->get('campaignchain.core.campaign');

--- a/Controller/RepeatingController.php
+++ b/Controller/RepeatingController.php
@@ -11,12 +11,7 @@
 namespace CampaignChain\Campaign\RepeatingBundle\Controller;
 
 use CampaignChain\Campaign\TemplateBundle\Controller\TemplateController;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use CampaignChain\CoreBundle\Entity\Campaign;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use CampaignChain\CoreBundle\Entity\Module;
-use CampaignChain\CoreBundle\Entity\Action;
 
 class RepeatingController extends TemplateController
 {
@@ -31,14 +26,12 @@ class RepeatingController extends TemplateController
         $fromCampaign = $campaignService->getCampaign($id);
         $campaignURI = $campaignService->getCampaignURI($fromCampaign);
 
-        switch($campaignURI){
+        switch ($campaignURI) {
             case 'campaignchain/campaign-repeating/campaignchain-repeating':
                 $toCampaign = clone $fromCampaign;
-                $toCampaign->setName($fromCampaign->getName().' (copied)');
+                $toCampaign->setName($fromCampaign->getName() . ' (copied)');
 
-                $campaignType = $this->get('campaignchain.core.form.type.campaign');
-                $campaignType->setBundleName(static::BUNDLE_NAME);
-                $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+                $campaignType = $this->getCampaignType();
                 $campaignType->setHooksOptions(
                     array(
                         'campaignchain-timespan' => array(
@@ -58,31 +51,29 @@ class RepeatingController extends TemplateController
                         $form->get('campaignchain_hook_campaignchain_date_repeat')->getData(),
                         $toCampaign->getName());
 
-                    $this->get('session')->getFlashBag()->add(
+                    $this->addFlash(
                         'success',
-                        'The '.static::CAMPAIGN_DISPLAY_NAME.' <a href="'.$this->generateUrl(
+                        'The ' . static::CAMPAIGN_DISPLAY_NAME . ' <a href="' . $this->generateUrl(
                             'campaignchain_core_campaign_edit',
-                            array('id' => $clonedCampaign->getId())).'">'.
-                        $clonedCampaign->getName().'</a> was copied successfully.'
+                            array('id' => $clonedCampaign->getId())) . '">' .
+                        $clonedCampaign->getName() . '</a> was copied successfully.'
                     );
 
-                    return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+                    return $this->redirectToRoute('campaignchain_core_campaign');
                 }
 
                 return $this->render(
                     'CampaignChainCoreBundle:Base:new.html.twig',
                     array(
-                        'page_title' => 'Copy '.static::CAMPAIGN_DISPLAY_NAME,
+                        'page_title' => 'Copy ' . static::CAMPAIGN_DISPLAY_NAME,
                         'form' => $form->createView(),
                     ));
                 break;
             case 'campaignchain/campaign-template/campaignchain-template':
                 $toCampaign = clone $fromCampaign;
-                $toCampaign->setName($fromCampaign->getName().' (copied)');
+                $toCampaign->setName($fromCampaign->getName() . ' (copied)');
 
-                $campaignType = $this->get('campaignchain.core.form.type.campaign');
-                $campaignType->setBundleName(static::BUNDLE_NAME);
-                $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+                $campaignType = $this->getCampaignType();
                 $campaignType->setHooksOptions(
                     array(
                         'campaignchain-timespan' => array(
@@ -102,31 +93,29 @@ class RepeatingController extends TemplateController
                         $form->get('campaignchain_hook_campaignchain_date_repeat')->getData(),
                         $toCampaign->getName());
 
-                    $this->get('session')->getFlashBag()->add(
+                    $this->addFlash(
                         'success',
-                        'The '.static::CAMPAIGN_DISPLAY_NAME.' <a href="'.$this->generateUrl(
+                        'The ' . static::CAMPAIGN_DISPLAY_NAME . ' <a href="' . $this->generateUrl(
                             'campaignchain_core_campaign_edit',
-                            array('id' => $clonedCampaign->getId())).'">'.
-                        $clonedCampaign->getName().'</a> was copied successfully.'
+                            array('id' => $clonedCampaign->getId())) . '">' .
+                        $clonedCampaign->getName() . '</a> was copied successfully.'
                     );
 
-                    return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+                    return $this->redirectToRoute('campaignchain_core_campaign');
                 }
 
                 return $this->render(
                     'CampaignChainCoreBundle:Base:new.html.twig',
                     array(
-                        'page_title' => 'Copy '.static::CAMPAIGN_DISPLAY_NAME,
+                        'page_title' => 'Copy ' . static::CAMPAIGN_DISPLAY_NAME,
                         'form' => $form->createView(),
                     ));
                 break;
             case 'campaignchain/campaign-scheduled/campaignchain-scheduled':
                 $toCampaign = clone $fromCampaign;
 
-                $toCampaign->setName($toCampaign->getName().' (copied)');
-                $campaignType = $this->get('campaignchain.core.form.type.campaign');
-                $campaignType->setBundleName(static::BUNDLE_NAME);
-                $campaignType->setModuleIdentifier(static::MODULE_IDENTIFIER);
+                $toCampaign->setName($toCampaign->getName() . ' (copied)');
+                $campaignType = $this->getCampaignType();
                 $campaignType->setHooksOptions(
                     array(
                         'campaignchain-timespan' => array(
@@ -146,18 +135,19 @@ class RepeatingController extends TemplateController
                         $form->get('campaignchain_hook_campaignchain_date_repeat')->getData(),
                         $toCampaign->getName());
 
-                    $this->get('session')->getFlashBag()->add(
+                    $this->addFlash(
                         'success',
-                        'The campaign template <a href="'.$this->generateUrl('campaignchain_core_campaign_edit', array('id' => $clonedCampaign->getId())).'">'.$clonedCampaign->getName().'</a> was copied successfully.'
+                        'The campaign template <a href="' . $this->generateUrl('campaignchain_core_campaign_edit',
+                            array('id' => $clonedCampaign->getId())) . '">' . $clonedCampaign->getName() . '</a> was copied successfully.'
                     );
 
-                    return $this->redirect($this->generateUrl('campaignchain_core_campaign'));
+                    return $this->redirectToRoute('campaignchain_core_campaign');
                 }
 
                 return $this->render(
                     'CampaignChainCoreBundle:Base:new.html.twig',
                     array(
-                        'page_title' => 'Copy Scheduled Campaign as '.static::CAMPAIGN_DISPLAY_NAME,
+                        'page_title' => 'Copy Scheduled Campaign as ' . static::CAMPAIGN_DISPLAY_NAME,
                         'form' => $form->createView(),
                     ));
 

--- a/Controller/RepeatingPlanController.php
+++ b/Controller/RepeatingPlanController.php
@@ -10,8 +10,6 @@
 
 namespace CampaignChain\Campaign\RepeatingBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
 use CampaignChain\Campaign\TemplateBundle\Controller\PlanController;
 
 class RepeatingPlanController extends PlanController


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
